### PR TITLE
register json.RawMessage to gob on init to solve gob encode issue

### DIFF
--- a/pkg/speculator/speculator.go
+++ b/pkg/speculator/speculator.go
@@ -17,6 +17,7 @@ package speculator
 
 import (
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -225,6 +226,11 @@ func (s *Speculator) ApplyApprovedReview(specKey SpecKey, approvedReview *_spec.
 		return fmt.Errorf("failed to apply approved review for spec: %v. %w", specKey, err)
 	}
 	return nil
+}
+
+// to solve "failed to encode state: gob: type not registered for interface: json.RawMessage"
+func init() {
+	gob.Register(json.RawMessage(nil))
 }
 
 func (s *Speculator) EncodeState(filePath string) error {


### PR DESCRIPTION
fix for:
`ERROR[2022-08-02T15:28:15+03:00]/Users/alexeik/go/src/github.com/openclarity/apiclarity/backend/pkg/backend/backend.go:414 github.com/openclarity/apiclarity/backend/pkg/backend.(*Backend).startStateBackup.func1() Failed to encode state: failed to encode state: gob: type not registered for interface: json.RawMessage`
