### PR TITLE
Fix nil context causing a panic with kin-openapi v0.101.0

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -16,6 +16,7 @@
 package spec
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -308,6 +309,7 @@ func (s *Spec) SpecInfoClone() (*Spec, error) {
 
 func LoadAndValidateRawJSONSpecV3(spec []byte) (*oapi_spec.T, error) {
 	loader := oapi_spec.NewLoader()
+	loader.Context = context.TODO()
 
 	doc, err := loader.LoadFromData(spec)
 	if err != nil {
@@ -323,6 +325,9 @@ func LoadAndValidateRawJSONSpecV3(spec []byte) (*oapi_spec.T, error) {
 }
 
 func LoadAndValidateRawJSONSpecV3FromV2(spec []byte) (*oapi_spec.T, error) {
+	loader := oapi_spec.NewLoader()
+	loader.Context = context.TODO()
+
 	var doc openapi2.T
 	if err := json.Unmarshal(spec, &doc); err != nil {
 		return nil, fmt.Errorf("provided spec is not valid. %w", err)
@@ -333,7 +338,7 @@ func LoadAndValidateRawJSONSpecV3FromV2(spec []byte) (*oapi_spec.T, error) {
 		return nil, fmt.Errorf("conversion to V3 failed. %w", err)
 	}
 
-	err = v3.Validate(oapi_spec.NewLoader().Context)
+	err = v3.Validate(loader.Context)
 	if err != nil {
 		return nil, fmt.Errorf("spec validation failed. %v. %w", err, errors.ErrSpecValidation)
 	}


### PR DESCRIPTION
An update to kin-openapi causes a panic when a nil context is passed to the `Validate` funcs. This change ensures that the context is not nil.

```sh
panic: cannot create context from nil parent

goroutine 114 [running]:
context.WithValue({0x0?, 0x0?}, {0x93e1a0?, 0x124d060?}, {0x8b8e40?, 0x4002a8f848?})
        /usr/local/go/src/context/context.go:525 +0x174
github.com/getkin/kin-openapi/openapi3.WithValidationOptions(...)
        /go/pkg/mod/github.com/getkin/kin-openapi@v0.101.0/openapi3/validation_options.go:32
github.com/getkin/kin-openapi/openapi3.(*T).Validate(0x40002547e0, {0x0, 0x0}, {0x0, 0x0, 0x307ae0?})
        /go/pkg/mod/github.com/getkin/kin-openapi@v0.101.0/openapi3/openapi3.go:63 +0xa0
github.com/openclarity/speculator/pkg/spec.LoadAndValidateRawJSONSpecV3FromV2({0x40027d9500, 0x34ed, 0x3500})
        /go/pkg/mod/github.com/openclarity/speculator@v0.1.1/pkg/spec/spec.go:287 +0x12c
github.com/openclarity/speculator/pkg/spec.LoadAndValidateRawJSONSpec({0x40027d6000, 0x34ed, 0x34ed})
        /go/pkg/mod/github.com/openclarity/speculator@v0.1.1/pkg/spec/provided_spec.go:76 +0x298
github.com/openclarity/speculator/pkg/spec.(*Spec).LoadProvidedSpec(0x400279e5a0, {0x40027d6000?, 0x40002501b0?, 0x28?}, 0x1f8?)
        /go/pkg/mod/github.com/openclarity/speculator@v0.1.1/pkg/spec/provided_spec.go:35 +0x38
github.com/openclarity/speculator/pkg/speculator.(*Speculator).LoadProvidedSpec(0x40000be2c0?, {0x40002501b0, 0x28}, {0x40027d6000, 0x34ed, 0x34ed}, 0x19?)
        /go/pkg/mod/github.com/openclarity/speculator@v0.1.1/pkg/speculator/speculator.go:174 +0x70
```