### PR TITLE
Consistently return wrapped errors for loading specs.

### DIFF
--- a/pkg/spec/provided_spec.go
+++ b/pkg/spec/provided_spec.go
@@ -16,6 +16,7 @@
 package spec
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,8 +29,8 @@ import (
 
 // Sentinel errors for spec version issues.
 var (
-	ErrUnknownSpecVersion     = fmt.Errorf("unknown spec version")
-	ErrUnsupportedSpecVersion = fmt.Errorf("unsupported spec version")
+	ErrUnknownSpecVersion     = errors.New("unknown spec version")
+	ErrUnsupportedSpecVersion = errors.New("unsupported spec version")
 )
 
 type ProvidedSpec struct {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -313,7 +313,7 @@ func LoadAndValidateRawJSONSpecV3(spec []byte) (*oapi_spec.T, error) {
 
 	doc, err := loader.LoadFromData(spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load data: %s. %v", spec, err)
+		return nil, fmt.Errorf("failed to load data: %s. %w", spec, err)
 	}
 
 	err = doc.Validate(loader.Context)


### PR DESCRIPTION
OASv2 specs were returning wrapped errors but valuable diagnostic information was lost for OASv3 specs. I've also created new sentinel errors to return when there is a problematic spec version.